### PR TITLE
Make Mesos listen address configurable separately

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -54,6 +54,7 @@ class seed_stack::controller (
 
   # Mesos
   $mesos_ensure           = $seed_stack::params::mesos_ensure,
+  $mesos_listen_addr      = $seed_stack::params::mesos_listen_addr,
   $mesos_cluster          = $seed_stack::params::mesos_cluster,
 
   # Marathon
@@ -74,6 +75,7 @@ class seed_stack::controller (
   # Basic parameter validation
   validate_ip_address($address)
   validate_bool($install_java)
+  validate_ip_address($mesos_listen_addr)
   validate_ip_address($consul_client_addr)
   validate_bool($consul_ui)
   validate_integer($consular_sync_interval)
@@ -99,7 +101,7 @@ class seed_stack::controller (
   class { 'mesos':
     ensure         => $mesos_ensure,
     repo           => 'mesosphere',
-    listen_address => $address,
+    listen_address => $mesos_listen_addr,
     zookeeper      => $mesos_zk,
   }
 

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -17,6 +17,9 @@
 # [*mesos_ensure*]
 #   The package ensure value for Mesos.
 #
+# [*mesos_listen_addr*]
+#   The address that Mesos will listen on.
+#
 # [*mesos_cluster*]
 #   The Mesos cluster name.
 #

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@ class seed_stack::params {
   $docker_ensure            = '1.9.1*'
 
   $mesos_ensure             = '0.24.1*'
+  $mesos_listen_addr        = '0.0.0.0'
   $mesos_cluster            = 'seed-stack'
   $mesos_resources          = {}
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -15,7 +15,6 @@ class seed_stack::params {
   }
 
   $consul_version           = '0.6.1'
-  $consul_advertise_addr    = '127.0.0.1'
   $consul_client_addr       = '0.0.0.0'
   $consul_domain            = 'consul.'
 

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -51,6 +51,7 @@ class seed_stack::worker (
 
   # Mesos
   $mesos_ensure            = $seed_stack::params::mesos_ensure,
+  $mesos_listen_addr       = $seed_stack::params::mesos_listen_addr,
   $mesos_resources         = $seed_stack::params::mesos_resources,
 
   # Consul
@@ -70,6 +71,7 @@ class seed_stack::worker (
   # Basic parameter validation
   validate_ip_address($address)
   validate_bool($controller)
+  validate_ip_address($mesos_listen_addr)
   validate_hash($mesos_resources)
   validate_ip_address($consul_client_addr)
   validate_bool($consul_ui)
@@ -79,7 +81,7 @@ class seed_stack::worker (
     class { 'mesos':
       ensure         => $mesos_ensure,
       repo           => 'mesosphere',
-      listen_address => $address,
+      listen_address => $mesos_listen_addr,
       zookeeper      => $mesos_zk,
     }
 

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -17,6 +17,9 @@
 # [*mesos_ensure*]
 #   The package ensure value for Mesos.
 #
+# [*mesos_listen_addr*]
+#   The address that Mesos will listen on.
+#
 # [*mesos_resources*]
 #   A hash of the available Mesos resources for the node.
 #


### PR DESCRIPTION
Sometimes it's useful to be able to set it to `0.0.0.0` if the controllers and workers communicate over a private interface while we still want the UI available over a public interface.
