### PR TITLE
Make Zookeeper clientPortAddress configurable

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -114,7 +114,12 @@ class seed_stack::controller (
   class { 'zookeeper':
     ensure    => $zookeeper_ensure,
     servers   => $controller_addresses,
-    client_ip => $zookeeper_client_addr
+    client_ip => $zookeeper_client_addr,
+    # FIXME: The deric/zookeeper module uses the old default value for
+    # `maxClientCnxns` of 10. Since Zookeeper 3.4.0 the default has been 60.
+    # Ubuntu 14.04 ships with Zookeeper 3.4.5. With a 2-node controller/worker
+    # setup, there are already 8 Zookeeper client connections open.
+    max_allowed_connections => 60,
   }
 
   $mesos_zk = inline_template('zk://<%= @controller_addresses.map { |c| "#{c}:2181"}.join(",") %>/mesos')

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -3,7 +3,8 @@
 # === Parameters
 #
 # [*controller_addresses*]
-#   A list of IP addresses for all controllers in the cluster.
+#   A list of IP addresses for all controllers in the cluster. NOTE: This list
+#   must be identical (same elements, same order) for ALL controller nodes.
 #
 # [*address*]
 #   The IP address for the node. All services will be exposed on this address.
@@ -111,8 +112,10 @@ class seed_stack::controller (
     Package['oracle-java8-installer'] -> Package['marathon']
   }
 
+  $zk_id = inline_template('<%= (@controller_addresses.find_index(@address) || 0) + 1 %>')
   class { 'zookeeper':
     ensure    => $zookeeper_ensure,
+    id        => $zk_id,
     servers   => $controller_addresses,
     client_ip => $zookeeper_client_addr,
     # FIXME: The deric/zookeeper module uses the old default value for

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -17,6 +17,9 @@
 # [*install_java*]
 #   Whether or not to install Oracle Java 8.
 #
+# [*zookeeper_client_addr*]
+#   The address that Zookeeper will listen for clients on.
+#
 # [*mesos_ensure*]
 #   The package ensure value for Mesos.
 #
@@ -58,6 +61,9 @@ class seed_stack::controller (
   $hostname               = $::hostname,
   $controller_worker      = false,
   $install_java           = true,
+
+  # Zookeeper
+  $zookeeper_client_addr  = $seed_stack::params::zookeeper_client_addr,
 
   # Mesos
   $mesos_ensure           = $seed_stack::params::mesos_ensure,
@@ -102,7 +108,7 @@ class seed_stack::controller (
 
   class { 'zookeeper':
     servers   => $controller_addresses,
-    client_ip => $address
+    client_ip => $zookeeper_client_addr
   }
 
   $mesos_zk = inline_template('zk://<%= @controller_addresses.map { |c| "#{c}:2181"}.join(",") %>/mesos')

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -17,6 +17,10 @@
 # [*install_java*]
 #   Whether or not to install Oracle Java 8.
 #
+# [*zookeeper_ensure*]
+#   The package ensure value for Zookeeper (note this is for all Zookeeper
+#   packages - i.e. 'zookeeper' and 'zookeeperd').
+#
 # [*zookeeper_client_addr*]
 #   The address that Zookeeper will listen for clients on.
 #
@@ -63,6 +67,7 @@ class seed_stack::controller (
   $install_java           = true,
 
   # Zookeeper
+  $zookeeper_ensure       = $seed_stack::params::zookeeper_ensure,
   $zookeeper_client_addr  = $seed_stack::params::zookeeper_client_addr,
 
   # Mesos
@@ -107,6 +112,7 @@ class seed_stack::controller (
   }
 
   class { 'zookeeper':
+    ensure    => $zookeeper_ensure,
     servers   => $controller_addresses,
     client_ip => $zookeeper_client_addr
   }

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -114,10 +114,10 @@ class seed_stack::controller (
 
   $zk_id = inline_template('<%= (@controller_addresses.find_index(@address) || 0) + 1 %>')
   class { 'zookeeper':
-    ensure    => $zookeeper_ensure,
-    id        => $zk_id,
-    servers   => $controller_addresses,
-    client_ip => $zookeeper_client_addr,
+    ensure                  => $zookeeper_ensure,
+    id                      => $zk_id,
+    servers                 => $controller_addresses,
+    client_ip               => $zookeeper_client_addr,
     # FIXME: The deric/zookeeper module uses the old default value for
     # `maxClientCnxns` of 10. Since Zookeeper 3.4.0 the default has been 60.
     # Ubuntu 14.04 ships with Zookeeper 3.4.5. With a 2-node controller/worker

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,7 @@ class seed_stack::params {
 
   $docker_ensure            = '1.9.1*'
 
+  $zookeeper_ensure         = 'present'
   $zookeeper_client_addr    = '0.0.0.0'
 
   $mesos_ensure             = '0.24.1*'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,6 +4,8 @@ class seed_stack::params {
 
   $docker_ensure            = '1.9.1*'
 
+  $zookeeper_client_addr    = '0.0.0.0'
+
   $mesos_ensure             = '0.24.1*'
   $mesos_listen_addr        = '0.0.0.0'
   $mesos_cluster            = 'seed-stack'


### PR DESCRIPTION
The standard Zookeeper package does not set the `clientPortAddress` parameter and by default Zookeeper listens on all interfaces.

The module we use for Zookeeper (deric/zookeeper) always sets the `clientPortAddress` parameter (with the value of the `client_ip` parameter). At the moment we are setting that value to the address of the node.

The script we use to check the status of Zookeeper (`/usr/share/zookeeper/bin/zkServer.sh`) is hard-coded to expect Zookeeper to be available at `localhost`. However, there are other ways we can check on the status of Zookeeper using a specific interface.

For all other services we have the "listen address" configurable, so we should do this for Zookeeper too.
