### PR TITLE
Use more reliable download method for praekeltfoundation modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.1 - UNRELEASED
+### Changes
+* Source praekeltfoundation modules from Puppet Forge (#10)
+
 ## 0.2.0 - 2016/01/12
 ### Features
 * `seed_stack::load_balancer` added for exposing services externally (#11)

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,15 +1,9 @@
 forge "https://forgeapi.puppetlabs.com"
 
 # Praekelt Foundation modules
-mod 'praekeltfoundation/consular',
-  :git => 'https://github.com/praekeltfoundation/puppet-consular.git',
-  :ref => '0.1.0'
-mod 'praekeltfoundation/marathon',
-  :git => 'https://github.com/praekeltfoundation/puppet-marathon.git',
-  :ref => '0.1.0'
-mod 'praekeltfoundation/webupd8_oracle_java',
-  :git => 'https://github.com/praekeltfoundation/puppet-webupd8_oracle_java.git',
-  :ref => '0.1.1'
+mod 'praekeltfoundation/consular', '>= 0.1.1'
+mod 'praekeltfoundation/marathon', '>= 0.1.1'
+mod 'praekeltfoundation/webupd8_oracle_java', '>= 0.1.2'
 
 # 3rd party modules
 mod 'deric/mesos', '>= 0.6.4'

--- a/Puppetfile
+++ b/Puppetfile
@@ -1,13 +1,4 @@
 forge "https://forgeapi.puppetlabs.com"
 
-# Praekelt Foundation modules
-mod 'praekeltfoundation/consular', '>= 0.1.1'
-mod 'praekeltfoundation/marathon', '>= 0.1.1'
-mod 'praekeltfoundation/webupd8_oracle_java', '>= 0.1.2'
-
-# 3rd party modules
-mod 'deric/mesos', '>= 0.6.4'
-mod 'deric/zookeeper', '>= 0.4.0'
-mod 'garethr/docker', '>= 4.1.0'
-mod 'gdhbashton/consul_template', '>= 0.2.4'
-mod 'KyleAnderson/consul', '>= 1.0.4'
+# use dependencies defined in metadata.json
+metadata

--- a/README.md
+++ b/README.md
@@ -71,9 +71,9 @@ Different parts of the class can be disabled if the node it is being included on
 We make use of quite a few Puppet modules to manage all the various pieces of software that make up Seed Stack. See the [Puppetfile](Puppetfile) for a complete listing with version information.
 
 Firstly, we wrote some modules ourselves:
-* [praekeltfoundation/consular](https://github.com/praekeltfoundation/puppet-consular)
-* [praekeltfoundation/marathon](https://github.com/praekeltfoundation/puppet-marathon)
-* [praekeltfoundation/webupd8_oracle_java](https://github.com/praekeltfoundation/puppet-webupd8_oracle_java)
+* [praekeltfoundation/consular](https://forge.puppetlabs.com/praekeltfoundation/consular)
+* [praekeltfoundation/marathon](https://forge.puppetlabs.com/praekeltfoundation/marathon)
+* [praekeltfoundation/webupd8_oracle_java](https://forge.puppetlabs.com/praekeltfoundation/webupd8_oracle_java)
 
 Then there are some 3rd party modules:
 * [deric/mesos](https://forge.puppetlabs.com/deric/mesos)

--- a/metadata.json
+++ b/metadata.json
@@ -7,7 +7,40 @@
   "source": "http://github.com/praekeltfoundation/puppet-seed_stack",
   "project_page": "https://github.com/praekeltfoundation/puppet-seed_stack",
   "issues_url": "https://github.com/praekeltfoundation/puppet-seed_stack/issues",
-  "dependencies": [],
+  "dependencies": [
+    {
+      "name": "praekeltfoundation/consular",
+      "version_requirement": ">=0.1.1"
+    },
+    {
+      "name": "praekeltfoundation/marathon",
+      "version_requirement": ">=0.1.1"
+    },
+    {
+      "name": "praekeltfoundation/webupd8_oracle_java",
+      "version_requirement": ">=0.1.2"
+    },
+    {
+      "name": "deric/mesos",
+      "version_requirement": ">=0.6.4"
+    },
+    {
+      "name": "deric/zookeeper",
+      "version_requirement": ">=0.4.0"
+    },
+    {
+      "name": "garethr/docker",
+      "version_requirement": ">=4.1.0"
+    },
+    {
+      "name": "gdhbashton/consul_template",
+      "version_requirement": ">=0.2.4"
+    },
+    {
+      "name": "KyleAnderson/consul",
+      "version_requirement": ">=1.0.4"
+    }
+  ],
   "requirements": [
     {
       "name": "puppet",


### PR DESCRIPTION
The Github API seems to throttle tarball downloads quite easily. Use Puppet Forge releases or straight git rather.
