### PR TITLE
Set Mesos advertise_ip

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -136,8 +136,9 @@ class seed_stack::controller (
   class { 'mesos::master':
     cluster => $mesos_cluster,
     options => {
-      hostname => $hostname,
-      quorum   => inline_template('<%= (@controller_addresses.size() / 2 + 1).floor() %>'),
+      hostname     => $hostname,
+      advertise_ip => $address,
+      quorum       => inline_template('<%= (@controller_addresses.size() / 2 + 1).floor() %>'),
     },
   }
 

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -115,6 +115,7 @@ class seed_stack::worker (
     resources => $mesos_resources,
     options   => {
       hostname                      => $hostname,
+      advertise_ip                  => $address,
       containerizers                => 'docker,mesos',
       executor_registration_timeout => '5mins',
     },

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -115,7 +115,10 @@ class seed_stack::worker (
     resources => $mesos_resources,
     options   => {
       hostname                      => $hostname,
-      advertise_ip                  => $address,
+      # FIXME: --advertise_ip for slaves was supposed to be added in Mesos 0.26
+      # but never actually made it in. Enable this if/when we get to 0.27.
+      # https://issues.apache.org/jira/browse/MESOS-3809
+      #advertise_ip                  => $address,
       containerizers                => 'docker,mesos',
       executor_registration_timeout => '5mins',
     },


### PR DESCRIPTION
Without setting the advertise_ip, Mesos will try resolve the hostname of the master or slave in order to get this value.

On a host with a nicely set-up `/etc/hosts` this is not usually a problem as the hostname will resolve to the desired IP. On a lot of machines, however, the hostname is set to resolve to `127.0.1.1` if it hasn't been explicitly configured.

We have an `$address` parameter we can use for this already.
