### PR TITLE
Use FQDN as default hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.3 - UNRELEASED
 ### Changes
 * deric/zookeeper module version 0.4.2 - Zookeeper `maxClientCnxns` is no longer set. The default is used. This should have no effect as we were previously setting it to the default. (#21)
+* Default the `hostname` parameter to `$::fqdn`. This makes it easier for Marathon/Mesos/Nginx to look up other nodes, especially on a public network (although you probably shouldn't be doing that). (#24)
 
 ## 0.2.2 - 2016/01/14
 ### Changes

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -63,7 +63,7 @@ class seed_stack::controller (
   # Common
   $controller_addresses   = [$::ipaddress_lo],
   $address                = $::ipaddress_lo,
-  $hostname               = $::hostname,
+  $hostname               = $::fqdn,
   $controller_worker      = false,
   $install_java           = true,
 


### PR DESCRIPTION
Hostname often used for different parts of the system to resolve other nodes. FQDN is more explicit/unique than hostname.
