### PR TITLE
Update Consul

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,5 +118,5 @@ The package versions can be seen in the [params class source](manifests/params.p
 | Docker          | 1.9.1   |
 | Consul          | 0.6.3   |
 | Consular        | 1.2.0   |
-| Consul Template | 0.12.1  |
+| Consul Template | 0.12.2  |
 | Nginx           | System  |

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ The package versions can be seen in the [params class source](manifests/params.p
 | Marathon        | 0.14.0  |
 | Zookeeper       | System  |
 | Docker          | 1.9.1   |
-| Consul          | 0.6.1   |
+| Consul          | 0.6.3   |
 | Consular        | 1.2.0   |
 | Consul Template | 0.12.1  |
 | Nginx           | System  |

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,7 +17,7 @@ class seed_stack::params {
     'event_subscriber' => 'http_callback' # HTTP callbacks for Consular
   }
 
-  $consul_version           = '0.6.1'
+  $consul_version           = '0.6.3'
   $consul_client_addr       = '0.0.0.0'
   $consul_domain            = 'consul.'
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,5 +24,5 @@ class seed_stack::params {
   $consular_ensure          = '1.2.0*'
   $consular_sync_interval   = '300'
 
-  $consul_template_version  = '0.12.1'
+  $consul_template_version  = '0.12.2'
 }


### PR DESCRIPTION
Current version: 0.6.1
0.6.2 - Built with Go 1.5.3 which includes a security fix for TLS (which we don't currently use)
0.6.3 - Fixes an issue with running Consul in a container
0.6.4 (unreleased) - I'm hoping fixes some weirdness in the web UI
