### PR TITLE
Clean up Consular set up

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -208,14 +208,9 @@ class seed_stack::controller (
   }
 
   class { 'consular':
-    ensure        => $consular_ensure,
-    consular_args => [
-      "--host=${address}",
-      "--sync-interval=${consular_sync_interval}",
-      '--purge', # TODO: Make configurable
-      "--registration-id=${hostname}",
-      "--consul=http://${address}:8500",
-      "--marathon=http://${address}:8080",
-    ],
+    package_ensure => $consular_ensure,
+    consul         => "http://${consul_client_addr}:8500",
+    sync_interval  => $consular_sync_interval,
+    purge          => true,
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {
       "name": "praekeltfoundation/consular",
-      "version_requirement": ">=0.1.1"
+      "version_requirement": ">=0.2.0"
     },
     {
       "name": "praekeltfoundation/marathon",


### PR DESCRIPTION
Consular doesn't necessarily connect to the correct addresses for Consul/Marathon - it uses the node advertise address.
