### PR TITLE
Ensure unzip is installed before installing Consul Template

### DIFF
--- a/manifests/template_nginx.pp
+++ b/manifests/template_nginx.pp
@@ -51,8 +51,9 @@ class seed_stack::template_nginx (
     # For some reason, consul-template doesn't like this option.
     # consul_max_stale => '10m',
     log_level    => 'warn',
-    require      => Package['unzip']
   }
+  # FIXME: See gdhbashton/puppet-consul_template#61
+  Package['unzip'] -> Class['consul_template::install']
 
   # Configure Nginx to load-balance across uptream services
   file { '/etc/consul-template/nginx-upstreams.ctmpl':


### PR DESCRIPTION
We already do a `require => Package['unzip']` on the `class { 'consul_template':...` but that's not enough because that class doesn't _contain_ the Consul Template install class. Oh Puppet...
