### PR TITLE
Reserve a certain amount of RAM for Mesos tasks on workers

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -11,6 +11,8 @@ class seed_stack::params {
   $mesos_listen_addr        = '0.0.0.0'
   $mesos_cluster            = 'seed-stack'
   $mesos_resources          = {}
+  $mesos_reserved_mem       = 1024
+  $mesos_minimum_mem        = 256
 
   $marathon_ensure          = '0.14.0*'
   $marathon_default_options = { # TODO


### PR DESCRIPTION
At the moment in the QA cluster we reserve 512MB of RAM to not be available for Mesos tasks. Mesos by default reserves 1024MB (_I think_). 512MB is probably a bit low but it would be good to be able to specify this value easily.
