### PR TITLE
Fix boolean parsing in nginx-services.ctmpl

### DIFF
--- a/files/nginx-services.ctmpl
+++ b/files/nginx-services.ctmpl
@@ -13,7 +13,7 @@ server {
     location {{$labels.location | parseJSON}} {
         proxy_pass http://{{.Name}};
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header Host $http_host;{{if $labels.internal}}{{if $labels.internal | parseJSON}}
+        proxy_set_header Host $http_host;{{if $labels.internal}}{{if $labels.internal | parseJSON | parseBool}}
         internal;{{end}}{{end}}
     }
     {{else}}


### PR DESCRIPTION
Needs a `| parseBool`
