### PR TITLE
docker0 interface facts not available on first Puppet run

### DIFF
--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -162,6 +162,6 @@ class seed_stack::worker (
   # Docker, using the host for DNS
   class { 'docker':
     ensure => $docker_ensure,
-    dns    => $::ipaddress_docker0,
+    dns    => $address,
   }
 }


### PR DESCRIPTION
We're not actually setting the Docker container DNS server to the `docker0` address.
