### PR TITLE
Make setting up a cluster without messing around with /etc/hosts possible

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ The package versions can be seen in the [params class source](manifests/params.p
 
 | Package         | Version |
 |-----------------|---------|
-| Mesos           | 0.26.0  |
+| Mesos           | 0.27.0  |
 | Marathon        | 0.14.1  |
 | Zookeeper       | System  |
 | Docker          | 1.10.0  |

--- a/files/nginx-upstreams.ctmpl
+++ b/files/nginx-upstreams.ctmpl
@@ -4,7 +4,7 @@
 
 {{range services}}{{$labels := ls (print "consular/" .Name) | explode}}{{if or $labels.domain $labels.location}}
 upstream {{.Name}} { {{range service .Name}}
-    server {{.Address}}:{{.Port}};{{end}}
+    server {{.NodeAddress}}:{{.Port}}; # {{.Address}}{{end}}
 }
 {{else}}
 # Skipped service {{.Name}} as it does not have a KV domain or location entry.

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -7,7 +7,7 @@ class seed_stack::params {
   $zookeeper_ensure         = 'installed'
   $zookeeper_client_addr    = '0.0.0.0'
 
-  $mesos_ensure             = '0.26.0*'
+  $mesos_ensure             = '0.27.0*'
   $mesos_listen_addr        = '0.0.0.0'
   $mesos_cluster            = 'seed-stack'
   $mesos_resources          = {}

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -58,7 +58,7 @@ class seed_stack::worker (
   # Common
   $controller_addresses     = [$::ipaddress_lo],
   $address                  = $::ipaddress_lo,
-  $hostname                 = $::hostname,
+  $hostname                 = $::fqdn,
   $controller_worker        = false,
 
   # Mesos

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -117,10 +117,7 @@ class seed_stack::worker (
     resources => $mesos_resources,
     options   => {
       hostname                      => $hostname,
-      # FIXME: --advertise_ip for slaves was supposed to be added in Mesos 0.26
-      # but never actually made it in. Enable this if/when we get to 0.27.
-      # https://issues.apache.org/jira/browse/MESOS-3809
-      #advertise_ip                  => $address,
+      advertise_ip                  => $address,
       containerizers                => 'docker,mesos',
       executor_registration_timeout => '5mins',
     },


### PR DESCRIPTION
Used to be #20 but I made a bad PR on the wrong issue.

```
JayH5 commented 6 days ago
See #19.

Also, nginx makes use of hostname lookup which may not be necessary.
```

```
JayH5 commented a day ago
There are tradeoffs here... it could be possible to achieve this by using IP addresses instead of hostnames everywhere but it's often useful to know the hostnames of machines.

Maybe this just requires good docs...
```
