### PR TITLE
Make `controller_addresses` and `address` required parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,9 @@ class { 'seed_stack::controller':
   controller_worker    => true,
 }
 class { 'seed_stack::worker':
-  address           => $ipaddress_eth0,
-  controller_worker => true,
+  address              => $ipaddress_eth0,
+  controller_addresses => [$ipaddress_eth0],
+  controller_worker    => true,
 }
 ```
 **NOTE:** For combination controller/workers it is necessary to set `controller_worker => true` for both the `seed_stack::controller` class and the `seed_stack::worker` class so that the two classes do not conflict.

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -7,7 +7,8 @@
 #   must be identical (same elements, same order) for ALL controller nodes.
 #
 # [*address*]
-#   The IP address for the node. All services will be exposed on this address.
+#   The advertise IP address for the node. All services will be exposed on this
+#   address.
 #
 # [*hostname*]
 #   The hostname for the node.
@@ -67,8 +68,8 @@
 #   The interval in seconds between Consular syncs.
 class seed_stack::controller (
   # Common
-  $controller_addresses   = [$::ipaddress_lo],
-  $address                = $::ipaddress_lo,
+  $controller_addresses,
+  $address,
   $hostname               = $::fqdn,
   $controller_worker      = false,
   $install_java           = true,

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -101,11 +101,11 @@ class seed_stack::controller (
   $consular_ensure        = $seed_stack::params::consular_ensure,
   $consular_sync_interval = $seed_stack::params::consular_sync_interval,
 ) inherits seed_stack::params {
-
-  # Basic parameter validation
+  validate_array($controller_addresses)
   validate_ip_address($address)
   validate_bool($controller_worker)
   validate_bool($install_java)
+  validate_ip_address($zookeeper_client_addr)
   validate_ip_address($mesos_listen_addr)
   validate_ip_address($consul_client_addr)
   validate_bool($consul_ui)

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -92,8 +92,7 @@ class seed_stack::worker (
   # Docker
   $docker_ensure            = $seed_stack::params::docker_ensure,
 ) inherits seed_stack::params {
-
-  # Basic parameter validation
+  validate_array($controller_addresses)
   validate_ip_address($address)
   validate_bool($controller_worker)
   validate_ip_address($mesos_listen_addr)

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -6,7 +6,8 @@
 #   A list of IP addresses for all controllers in the cluster.
 #
 # [*address*]
-#   The IP address for the node. All services will be exposed on this address.
+#   The advertise IP address for the node. All services will be exposed on this
+#   address.
 #
 # [*hostname*]
 #   The hostname for the node.
@@ -60,8 +61,8 @@
 #   The package ensure value for Docker Engine.
 class seed_stack::worker (
   # Common
-  $controller_addresses     = [$::ipaddress_lo],
-  $address                  = $::ipaddress_lo,
+  $controller_addresses,
+  $address,
   $hostname                 = $::fqdn,
   $controller_worker        = false,
 

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -7,7 +7,7 @@ describe 'seed_stack::controller' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      describe 'controller_addresses and address are specified' do
+      describe 'when controller_addresses and address are passed' do
         let(:params) do
           {
             :controller_addresses => ['192.168.0.2'],
@@ -17,12 +17,12 @@ describe 'seed_stack::controller' do
         it { should compile }
       end
 
-      describe 'controller_addresses not specified' do
+      describe 'when controller_addresses is not passed' do
         let(:params) { { :address => '192.168.0.2', } }
         it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      describe 'address not specified' do
+      describe 'when address is not passed' do
         let(:params) { { :controller_addresses => ['192.168.0.2'], } }
         it { should compile.and_raise_error(/Must pass address/) }
       end

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -16,5 +16,21 @@ describe 'seed_stack::controller' do
 
       it { should compile }
     end
+
+    context 'controller_addresses is required' do
+      let(:params) do
+        { :address => '192.168.0.2', }
+      end
+
+      it { should compile.and_raise_error(/Must pass controller_addresses/) }
+    end
+
+    context 'address is required' do
+      let(:params) do
+        { :controller_addresses => ['192.168.0.2'], }
+      end
+
+      it { should compile.and_raise_error(/Must pass address/) }
+    end
   end
 end

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -7,6 +7,13 @@ describe 'seed_stack::controller' do
         facts
       end
 
+      let(:params) do
+        {
+          :controller_addresses => ['192.168.0.2'],
+          :address => '192.168.0.2',
+        }
+      end
+
       it { should compile }
     end
   end

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -4,33 +4,28 @@ describe 'seed_stack::controller' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
-        facts
+        facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      let(:params) do
-        {
-          :controller_addresses => ['192.168.0.2'],
-          :address => '192.168.0.2',
-        }
+      describe 'compiles when controller_addresses and address are specified' do
+        let(:params) do
+          {
+            :controller_addresses => ['192.168.0.2'],
+            :address => '192.168.0.2',
+          }
+        end
+        it { should compile }
       end
 
-      it { should compile }
-    end
-
-    context 'controller_addresses is required' do
-      let(:params) do
-        { :address => '192.168.0.2', }
+      describe 'controller_addresses must be specified' do
+        let(:params) { { :address => '192.168.0.2', } }
+        it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      it { should compile.and_raise_error(/Must pass controller_addresses/) }
-    end
-
-    context 'address is required' do
-      let(:params) do
-        { :controller_addresses => ['192.168.0.2'], }
+      describe 'address must be specified' do
+        let(:params) { { :controller_addresses => ['192.168.0.2'], } }
+        it { should compile.and_raise_error(/Must pass address/) }
       end
-
-      it { should compile.and_raise_error(/Must pass address/) }
     end
   end
 end

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -7,7 +7,7 @@ describe 'seed_stack::controller' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      describe 'compiles when controller_addresses and address are specified' do
+      describe 'controller_addresses and address are specified' do
         let(:params) do
           {
             :controller_addresses => ['192.168.0.2'],
@@ -17,12 +17,12 @@ describe 'seed_stack::controller' do
         it { should compile }
       end
 
-      describe 'controller_addresses must be specified' do
+      describe 'controller_addresses not specified' do
         let(:params) { { :address => '192.168.0.2', } }
         it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      describe 'address must be specified' do
+      describe 'address not specified' do
         let(:params) { { :controller_addresses => ['192.168.0.2'], } }
         it { should compile.and_raise_error(/Must pass address/) }
       end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -7,7 +7,7 @@ describe 'seed_stack::worker' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      describe 'controller_addresses and address are specified' do
+      describe 'when controller_addresses and address are passed' do
         let(:params) do
           {
             :controller_addresses => ['192.168.0.2'],
@@ -17,12 +17,12 @@ describe 'seed_stack::worker' do
         it { should compile }
       end
 
-      describe 'controller_addresses not specified' do
+      describe 'when controller_addresses is not passed' do
         let(:params) { { :address => '192.168.0.2', } }
         it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      describe 'address not specified' do
+      describe 'when address is not passed' do
         let(:params) { { :controller_addresses => ['192.168.0.2'], } }
         it { should compile.and_raise_error(/Must pass address/) }
       end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -7,30 +7,25 @@ describe 'seed_stack::worker' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      let(:params) do
-        {
-          :controller_addresses => ['192.168.0.2'],
-          :address => '192.168.0.3',
-        }
+      describe 'compiles when controller_addresses and address are specified' do
+        let(:params) do
+          {
+            :controller_addresses => ['192.168.0.2'],
+            :address => '192.168.0.3',
+          }
+        end
+        it { should compile }
       end
 
-      it { should compile }
-    end
-
-    context 'controller_addresses is required' do
-      let(:params) do
-        { :address => '192.168.0.2', }
+      describe 'controller_addresses must be specified' do
+        let(:params) { { :address => '192.168.0.2', } }
+        it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      it { should compile.and_raise_error(/Must pass controller_addresses/) }
-    end
-
-    context 'address is required' do
-      let(:params) do
-        { :controller_addresses => ['192.168.0.2'], }
+      describe 'address must be specified' do
+        let(:params) { { :controller_addresses => ['192.168.0.2'], } }
+        it { should compile.and_raise_error(/Must pass address/) }
       end
-
-      it { should compile.and_raise_error(/Must pass address/) }
     end
   end
 end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -7,7 +7,7 @@ describe 'seed_stack::worker' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
-      describe 'compiles when controller_addresses and address are specified' do
+      describe 'controller_addresses and address are specified' do
         let(:params) do
           {
             :controller_addresses => ['192.168.0.2'],
@@ -17,12 +17,12 @@ describe 'seed_stack::worker' do
         it { should compile }
       end
 
-      describe 'controller_addresses must be specified' do
+      describe 'controller_addresses not specified' do
         let(:params) { { :address => '192.168.0.2', } }
         it { should compile.and_raise_error(/Must pass controller_addresses/) }
       end
 
-      describe 'address must be specified' do
+      describe 'address not specified' do
         let(:params) { { :controller_addresses => ['192.168.0.2'], } }
         it { should compile.and_raise_error(/Must pass address/) }
       end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -16,5 +16,21 @@ describe 'seed_stack::worker' do
 
       it { should compile }
     end
+
+    context 'controller_addresses is required' do
+      let(:params) do
+        { :address => '192.168.0.2', }
+      end
+
+      it { should compile.and_raise_error(/Must pass controller_addresses/) }
+    end
+
+    context 'address is required' do
+      let(:params) do
+        { :controller_addresses => ['192.168.0.2'], }
+      end
+
+      it { should compile.and_raise_error(/Must pass address/) }
+    end
   end
 end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -7,6 +7,13 @@ describe 'seed_stack::worker' do
         facts.merge({:concat_basedir => '/tmp/puppetconcat'})
       end
 
+      let(:params) do
+        {
+          :controller_addresses => ['192.168.0.2'],
+          :address => '192.168.0.3',
+        }
+      end
+
       it { should compile }
     end
   end


### PR DESCRIPTION
Defaulting to `$::ipaddress_lo` is not very useful.
