### PR TITLE
Zookeeper is allowed to start on workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## 0.6.3 - UNRELEASED
+### Fixes
+* Install Mesos package with the `--no-install-recommends` flag when using versions of Puppet >= 3.6.0. This should ensure that Zookeeper is not installed unnecessarily. With older versions of Puppet, stop Zookeeper from running on workers. (#76)
 
 ## 0.6.2 - 2016/03/03
 ### Changes

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -142,6 +142,13 @@ class seed_stack::controller (
     listen_address => $mesos_listen_addr,
     zookeeper      => $mesos_zk,
   }
+  if versioncmp($::puppetversion, '3.6.0') >= 0 {
+    Package <| title == 'mesos' |> {
+      # Skip installing the recommended Mesos packages as they are just
+      # Zookeeper packages that are installed by the Zookeeper class anyway.
+      install_options => ['--no-install-recommends'],
+    }
+  }
 
   class { 'mesos::master':
     cluster => $mesos_cluster,

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -120,6 +120,21 @@ class seed_stack::worker (
       zookeeper      => $mesos_zk,
     }
 
+    if versioncmp($::puppetversion, '3.6.0') >= 0 {
+      Package <| title == 'mesos' |> {
+        # Skip installing the recommended Mesos packages as they are just
+        # Zookeeper packages that we don't need.
+        install_options => ['--no-install-recommends'],
+      }
+    } else {
+      # We can't *not* install Zookeeper but we can stop it from running.
+      service { 'zookeeper':
+        ensure  => stopped,
+        enable  => false,
+        require => Package['mesos'],
+      }
+    }
+
     # Make Puppet stop the mesos-master service
     service { 'mesos-master':
       ensure  => stopped,

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -151,6 +151,23 @@ describe 'seed_stack::controller' do
             .with_purge(true)
         end
       end
+
+      context 'Mesos package --no-install-recommends' do
+        let(:params) do
+          {
+            :controller_addrs => ['192.168.0.2'],
+            :advertise_addr => '192.168.0.2',
+          }
+        end
+        if Gem::Version.new(Puppet.version) >= Gem::Version.new('3.6.0')
+          it do
+            is_expected.to contain_package('mesos')
+              .with_install_options('--no-install-recommends')
+          end
+        else
+          it { is_expected.to contain_package('mesos').without_install_options }
+        end
+      end
     end
   end
 end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -102,6 +102,34 @@ describe 'seed_stack::worker' do
           is_expected.to compile.and_raise_error(/Must pass advertise_addr/)
         end
       end
+
+      context 'Mesos package --no-install-recommends' do
+        let(:params) do
+          {
+            :controller_addrs => ['192.168.0.2'],
+            :advertise_addr => '192.168.0.2',
+          }
+        end
+        if Gem::Version.new(Puppet.version) >= Gem::Version.new('3.6.0')
+          it do
+            is_expected.to contain_package('mesos')
+              .with_install_options('--no-install-recommends')
+          end
+
+          it do
+            is_expected.not_to contain_service('zookeeper')
+          end
+        else
+          it { is_expected.to contain_package('mesos').without_install_options }
+
+          it do
+            is_expected.to contain_service('zookeeper')
+              .with_ensure('stopped')
+              .with_enable(false)
+              .that_requires('Package[mesos]')
+          end
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Zookeeper shouldn't be running on workers but the service is not explicitly disabled.
