### PR TITLE
Disable Mesos syslog logging

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -151,8 +151,9 @@ class seed_stack::controller (
   }
 
   class { 'mesos::master':
-    cluster => $mesos_cluster,
-    options => {
+    cluster       => $mesos_cluster,
+    syslog_logger => false,
+    options       => {
       hostname     => $hostname,
       advertise_ip => $advertise_addr,
       quorum       => size($controller_addrs) / 2 + 1 # Note: integer division

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -151,9 +151,10 @@ class seed_stack::worker (
   }
 
   class { 'mesos::slave':
-    master    => $mesos_zk,
-    resources => $mesos_resources,
-    options   => {
+    master        => $mesos_zk,
+    resources     => $mesos_resources,
+    syslog_logger => false,
+    options       => {
       hostname                      => $hostname,
       advertise_ip                  => $advertise_addr,
       containerizers                => 'docker,mesos',

--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,7 @@
     },
     {
       "name": "deric-mesos",
-      "version_requirement": ">=0.6.5"
+      "version_requirement": ">=0.7.1 <0.8.0"
     },
     {
       "name": "deric-zookeeper",

--- a/spec/classes/controller_spec.rb
+++ b/spec/classes/controller_spec.rb
@@ -67,6 +67,7 @@ describe 'seed_stack::controller' do
         it do
           is_expected.to contain_class('mesos::master')
             .with_cluster('seed-stack')
+            .with_syslog_logger(false)
             .with_options(
               'hostname' => 'foo.example.com',
               'advertise_ip' => '192.168.0.2',

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -11,7 +11,7 @@ describe 'seed_stack::worker' do
         let(:params) do
           {
             :controller_addrs => ['192.168.0.2'],
-            :advertise_addr => '192.168.0.2',
+            :advertise_addr => '192.168.0.3',
           }
         end
 
@@ -26,12 +26,23 @@ describe 'seed_stack::worker' do
             .with_ensure('stopped')
         end
 
-        it { is_expected.to contain_class('mesos::slave') }
+        it do
+          is_expected.to contain_class('mesos::slave')
+            .with_master('zk://192.168.0.2:2181/mesos')
+            .with_resources({})
+            .with_syslog_logger(false)
+            .with_options(
+              'hostname' => 'foo.example.com',
+              'advertise_ip' => '192.168.0.3',
+              'containerizers' => 'docker,mesos',
+              'executor_registration_timeout' => '5mins'
+            )
+        end
 
         it do
           is_expected.to contain_class('seed_stack::consul_dns')
             .with_join('192.168.0.2')
-            .with_advertise_addr('192.168.0.2')
+            .with_advertise_addr('192.168.0.3')
         end
 
         it { is_expected.to contain_consul__service('mesos-slave') }


### PR DESCRIPTION
Easy disabling added in deric/mesos version 0.7.1

When syslog logging is disabled, things are logged by upstart rather.
