### PR TITLE
Don't expose service routers to the outside world

### DIFF
--- a/manifests/consul_dns.pp
+++ b/manifests/consul_dns.pp
@@ -71,7 +71,7 @@ class seed_stack::consul_dns (
   $recursors          = [$::ipaddress_lo],
 
   $dnsmasq_ensure     = 'installed',
-  $dnsmasq_host_alias = $seed_stack::params::nginx_router_domain,
+  $dnsmasq_host_alias = $seed_stack::params::router_domain,
   $dnsmasq_opts       = {},
 ) inherits seed_stack::params {
   validate_bool($server)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,7 +79,7 @@ class seed_stack::params {
   $consul_template_version  = '0.14.0'
 
   $nginx_ensure             = 'installed'
-  $router_listen_addr       = '0.0.0.0'
+  $router_listen_addr       = $::ipaddress_lo
   $router_listen_port       = 80
   $router_domain            = 'servicehost'
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,13 +49,13 @@
 # [*nginx_ensure*]
 #   The package ensure value for Nginx.
 #
-# [*nginx_router_listen_addr*]
+# [*router_listen_addr*]
 #   The address that Nginx should listen on when serving routing requests.
 #
-# [*nginx_router_listen_port*]
+# [*router_listen_port*]
 #   The port that Nginx should listen on when serving routing requests.
 #
-# [*nginx_router_domain*]
+# [*router_domain*]
 #   The domain that Nginx should serve for routing.
 class seed_stack::params {
   $docker_ensure            = '1.10.3-0~trusty'
@@ -79,7 +79,7 @@ class seed_stack::params {
   $consul_template_version  = '0.14.0'
 
   $nginx_ensure             = 'installed'
-  $nginx_router_listen_addr = '0.0.0.0'
-  $nginx_router_listen_port = 80
-  $nginx_router_domain      = 'servicehost'
+  $router_listen_addr       = '0.0.0.0'
+  $router_listen_port       = 80
+  $router_domain            = 'servicehost'
 }

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -14,9 +14,9 @@
 # [*domain*]
 #   The domain that Nginx should serve for routing.
 class seed_stack::router (
-  $listen_addr = $seed_stack::params::nginx_router_listen_addr,
-  $listen_port = $seed_stack::params::nginx_router_listen_port,
-  $domain      = $seed_stack::params::nginx_router_domain,
+  $listen_addr = $seed_stack::params::router_listen_addr,
+  $listen_port = $seed_stack::params::router_listen_port,
+  $domain      = $seed_stack::params::router_domain,
 ) inherits seed_stack::params {
   validate_ip_address($listen_addr)
   validate_integer($listen_port, 65535, 1)

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -6,7 +6,9 @@
 # === Parameters
 #
 # [*listen_addr*]
-#   The address that Nginx should listen on when serving requests.
+#   The address that Nginx should listen on when serving requests. NOTE: If you
+#   are using an address and port that are available from the outside internet,
+#   your services will be exposed via the router.
 #
 # [*listen_port*]
 #   The port that Nginx should listen on when serving requests.

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -110,7 +110,6 @@ class seed_stack::worker (
   validate_hash($mesos_resources)
   validate_ip_address($consul_client_addr)
   validate_bool($consul_ui)
-  validate_ip_address($router_listen_addr)
   validate_bool($gluster_client_manage)
 
   $zk_base = join(suffix($controller_addrs, ':2181'), ',')

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -55,7 +55,7 @@
 # [*nginx_ensure*]
 #   The ensure value for the Nginx package.
 #
-# [*nginx_router_listen_addr*]
+# [*router_listen_addr*]
 #   The address that Nginx should listen on when serving routing requests.
 #
 # [*docker_ensure*]
@@ -98,7 +98,7 @@ class seed_stack::worker (
 
   # Nginx
   $nginx_ensure             = $seed_stack::params::nginx_ensure,
-  $nginx_router_listen_addr = $seed_stack::params::nginx_router_listen_addr,
+  $router_listen_addr       = $seed_stack::params::router_listen_addr,
 
   # Docker
   $docker_ensure            = $seed_stack::params::docker_ensure,
@@ -114,7 +114,7 @@ class seed_stack::worker (
   validate_hash($mesos_resources)
   validate_ip_address($consul_client_addr)
   validate_bool($consul_ui)
-  validate_ip_address($nginx_router_listen_addr)
+  validate_ip_address($router_listen_addr)
   validate_bool($gluster_client_manage)
 
   $zk_base = join(suffix($controller_addrs, ':2181'), ',')
@@ -193,7 +193,7 @@ class seed_stack::worker (
     consul_address          => $consul_client_addr,
   }
   class { 'seed_stack::router':
-    listen_addr => $nginx_router_listen_addr,
+    listen_addr => $router_listen_addr,
     domain      => $dnsmasq_host_alias,
   }
 

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -55,9 +55,6 @@
 # [*nginx_ensure*]
 #   The ensure value for the Nginx package.
 #
-# [*router_listen_addr*]
-#   The address that Nginx should listen on when serving routing requests.
-#
 # [*docker_ensure*]
 #   The package ensure value for Docker Engine.
 #
@@ -98,7 +95,6 @@ class seed_stack::worker (
 
   # Nginx
   $nginx_ensure             = $seed_stack::params::nginx_ensure,
-  $router_listen_addr       = $seed_stack::params::router_listen_addr,
 
   # Docker
   $docker_ensure            = $seed_stack::params::docker_ensure,
@@ -193,7 +189,7 @@ class seed_stack::worker (
     consul_address          => $consul_client_addr,
   }
   class { 'seed_stack::router':
-    listen_addr => $router_listen_addr,
+    listen_addr => $advertise_addr,
     domain      => $dnsmasq_host_alias,
   }
 

--- a/spec/classes/router_spec.rb
+++ b/spec/classes/router_spec.rb
@@ -7,7 +7,47 @@ describe 'seed_stack::router' do
         facts.merge(:concat_basedir => '/tmp/puppetconcat')
       end
 
-      it { is_expected.to compile }
+      describe 'with default parameters' do
+        it { is_expected.to compile }
+
+        it { is_expected.to contain_class('seed_stack::template_nginx') }
+
+        it do
+          is_expected.to(
+            contain_file('/etc/consul-template/nginx-services.ctmpl')
+              .with_content(/^\s*listen 127\.0\.0\.1:80;$/)
+              .with_content(/^\s*server_name servicehost;$/)
+          )
+        end
+
+        it do
+          is_expected.to contain_consul_template__watch('nginx-services')
+            .with(
+              'source' => '/etc/consul-template/nginx-services.ctmpl',
+              'destination' => '/etc/nginx/sites-enabled/seed-services.conf',
+              'command' => '/etc/init.d/nginx reload'
+            ).that_subscribes_to(
+              'File[/etc/consul-template/nginx-services.ctmpl]')
+        end
+      end
+
+      describe 'with custom parameters' do
+        let(:params) do
+          {
+            :listen_addr => '192.168.0.1',
+            :listen_port => 8000,
+            :domain => 'dockerhost'
+          }
+        end
+
+        it do
+          is_expected.to(
+            contain_file('/etc/consul-template/nginx-services.ctmpl')
+              .with_content(/^\s*listen 192\.168\.0\.1:8000;$/)
+              .with_content(/^\s*server_name dockerhost;$/)
+          )
+        end
+      end
     end
   end
 end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -49,7 +49,11 @@ describe 'seed_stack::worker' do
 
         it { is_expected.to contain_class('seed_stack::template_nginx') }
 
-        it { is_expected.to contain_class('seed_stack::router') }
+        it do
+          is_expected.to contain_class('seed_stack::router')
+            .with_listen_addr('192.168.0.3')
+            .with_domain('servicehost')
+        end
 
         it { is_expected.to contain_class('docker') }
 


### PR DESCRIPTION
Nginx service routers listen on port 80 which is open to the world. Simplest solution is probably to just ~~move to a different port~~.

Instead moving to the `advertise_addr` by default which is hopefully internal.
