### PR TITLE
fix nginx website config

### DIFF
--- a/manifests/load_balancer.pp
+++ b/manifests/load_balancer.pp
@@ -2,11 +2,21 @@
 #
 # Defines a dynamically-cofigured Nginx load-balancer for external-facing apps.
 # Apps must define a 'domain' Marathon label to be accessible through Nginx.
-class seed_stack::load_balancer {
+#
+# === Parameters
+#
+# [*listen_addr*]
+#   The address that seed_stack::router is listening on. This prevents the more
+#   specific listen directive in that from masking our server blocks.
+class seed_stack::load_balancer (
+  $listen_addr = $seed_stack::params::router_listen_addr,
+) inherits seed_stack::params {
+  validate_ip_address($listen_addr)
+
   include seed_stack::template_nginx
 
   file { '/etc/consul-template/nginx-websites.ctmpl':
-    source => 'puppet:///modules/seed_stack/nginx-websites.ctmpl',
+    content => template('seed_stack/nginx-websites.ctmpl.erb'),
   }
   ~>
   consul_template::watch { 'nginx-websites':

--- a/spec/classes/load_balancer_spec.rb
+++ b/spec/classes/load_balancer_spec.rb
@@ -7,19 +7,35 @@ describe 'seed_stack::load_balancer' do
         facts.merge(:concat_basedir => '/tmp/puppetconcat')
       end
 
-      it { is_expected.to compile }
-      it { is_expected.to contain_class('seed_stack::template_nginx') }
-      it do
-        is_expected.to contain_file('/etc/consul-template/nginx-websites.ctmpl')
+      describe 'with default parameters' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('seed_stack::template_nginx') }
+        it do
+          is_expected.to contain_file(
+            '/etc/consul-template/nginx-websites.ctmpl')
+            .with_content(/^\s*listen 80;/)
+            .with_content(/^\s*listen 127\.0\.0\.1:80;/)
+        end
+        it do
+          is_expected.to contain_consul_template__watch('nginx-websites')
+            .with(
+              'source' => '/etc/consul-template/nginx-websites.ctmpl',
+              'destination' => '/etc/nginx/sites-enabled/seed-websites.conf',
+              'command' => '/etc/init.d/nginx reload'
+            ).that_subscribes_to(
+              'File[/etc/consul-template/nginx-websites.ctmpl]')
+        end
       end
-      it do
-        is_expected.to contain_consul_template__watch('nginx-websites')
-          .with(
-            'source' => '/etc/consul-template/nginx-websites.ctmpl',
-            'destination' => '/etc/nginx/sites-enabled/seed-websites.conf',
-            'command' => '/etc/init.d/nginx reload'
-          ).that_subscribes_to(
-            'File[/etc/consul-template/nginx-websites.ctmpl]')
+
+      describe 'with custom parameters' do
+        let(:params) { {:listen_addr => '192.168.0.1'} }
+
+        it do
+          is_expected.to contain_file(
+            '/etc/consul-template/nginx-websites.ctmpl')
+            .with_content(/^\s*listen 80;/)
+            .with_content(/^\s*listen 192\.168\.0\.1:80;/)
+        end
       end
     end
   end

--- a/templates/nginx-websites.ctmpl.erb
+++ b/templates/nginx-websites.ctmpl.erb
@@ -10,6 +10,7 @@
 {{range services}}{{$labels := ls (print "consular/" .Name) | explode }}{{if $labels.domain}}
 server {
   listen 80;
+  listen <%= @listen_addr %>:80; # Avoid being masked by listen directive in services config.
   server_name {{$labels.domain | parseJSON }};
 
   location / {


### PR DESCRIPTION
The `listen <ip>:80;` directive in the service config overrides the `listen 80;` directive in the website config, which means websites can't be reached on the interface `servicehost` points to.
