### PR TITLE
Move template_nginx options to params

### DIFF
--- a/manifests/load_balancer.pp
+++ b/manifests/load_balancer.pp
@@ -8,12 +8,44 @@
 # [*listen_addr*]
 #   The address that seed_stack::router is listening on. This prevents the more
 #   specific listen directive in that from masking our server blocks.
+#
+# [*nginx_manage*]
+#   Whether or not to manage the nginx service and package at all
+#
+# [*nginx_package*]
+#   The name of the Nginx package to install.
+#
+# [*nginx_package_ensure*]
+#   The ensure value for the Nginx package.
+#
+# [*nginx_service_ensure*]
+#   The ensure value for the Nginx service.
+#
+# [*consul_template_version*]
+#   The version of Consul Template to install.
+#
+# [*consul_address*]
+#   The address for the Consul agent for Consul Template to connect to.
 class seed_stack::load_balancer (
-  $listen_addr = $seed_stack::params::router_listen_addr,
+  $listen_addr             = $seed_stack::params::router_listen_addr,
+  $nginx_manage            = $seed_stack::params::nginx_manage,
+  $nginx_package           = $seed_stack::params::nginx_package,
+  $nginx_package_ensure    = $seed_stack::params::nginx_ensure,
+  $nginx_service_ensure    = $seed_stack::params::nginx_service_ensure,
+
+  $consul_template_version = $seed_stack::params::consul_template_version,
+  $consul_address          = $seed_stack::params::consul_client_addr,
 ) inherits seed_stack::params {
   validate_ip_address($listen_addr)
 
-  include seed_stack::template_nginx
+  class{ 'seed_stack::template_nginx':
+    nginx_manage            => $nginx_manage,
+    nginx_package           => $nginx_package,
+    nginx_package_ensure    => $nginx_package_ensure,
+    nginx_service_ensure    => $nginx_service_ensure,
+    consul_template_version => $consul_template_version,
+    consul_address          => $consul_address,
+  }
 
   file { '/etc/consul-template/nginx-websites.ctmpl':
     content => template('seed_stack/nginx-websites.ctmpl.erb'),

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -49,6 +49,15 @@
 # [*nginx_ensure*]
 #   The package ensure value for Nginx.
 #
+# [*nginx_manage*]
+#   Whether or not to manage the nginx service and package at all
+#
+# [*nginx_package*]
+#   The name of the Nginx package to install.
+#
+# [*nginx_service_ensure*]
+#   The ensure value for the Nginx service.
+#
 # [*router_listen_addr*]
 #   The address that Nginx should listen on when serving routing requests.
 #
@@ -79,6 +88,10 @@ class seed_stack::params {
   $consul_template_version  = '0.14.0'
 
   $nginx_ensure             = 'installed'
+  $nginx_manage             = true
+  $nginx_package            = 'nginx-light'
+  $nginx_service_ensure     = 'running'
+
   $router_listen_addr       = $::ipaddress_lo
   $router_listen_port       = 80
   $router_domain            = 'servicehost'

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -15,15 +15,47 @@
 #
 # [*domain*]
 #   The domain that Nginx should serve for routing.
+#
+# [*nginx_manage*]
+#   Whether or not to manage the nginx service and package at all
+#
+# [*nginx_package*]
+#   The name of the Nginx package to install.
+#
+# [*nginx_package_ensure*]
+#   The ensure value for the Nginx package.
+#
+# [*nginx_service_ensure*]
+#   The ensure value for the Nginx service.
+#
+# [*consul_template_version*]
+#   The version of Consul Template to install.
+#
+# [*consul_address*]
+#   The address for the Consul agent for Consul Template to connect to.
 class seed_stack::router (
-  $listen_addr = $seed_stack::params::router_listen_addr,
-  $listen_port = $seed_stack::params::router_listen_port,
-  $domain      = $seed_stack::params::router_domain,
+  $listen_addr             = $seed_stack::params::router_listen_addr,
+  $listen_port             = $seed_stack::params::router_listen_port,
+  $domain                  = $seed_stack::params::router_domain,
+  $nginx_manage            = $seed_stack::params::nginx_manage,
+  $nginx_package           = $seed_stack::params::nginx_package,
+  $nginx_package_ensure    = $seed_stack::params::nginx_ensure,
+  $nginx_service_ensure    = $seed_stack::params::nginx_service_ensure,
+
+  $consul_template_version = $seed_stack::params::consul_template_version,
+  $consul_address          = $seed_stack::params::consul_client_addr,
 ) inherits seed_stack::params {
   validate_ip_address($listen_addr)
   validate_integer($listen_port, 65535, 1)
 
-  include seed_stack::template_nginx
+  class{ 'seed_stack::template_nginx':
+    nginx_manage            => $nginx_manage,
+    nginx_package           => $nginx_package,
+    nginx_package_ensure    => $nginx_package_ensure,
+    nginx_service_ensure    => $nginx_service_ensure,
+    consul_template_version => $consul_template_version,
+    consul_address          => $consul_address,
+  }
 
   # Configure Nginx to route to upstream services
   file { '/etc/consul-template/nginx-services.ctmpl':

--- a/manifests/template_nginx.pp
+++ b/manifests/template_nginx.pp
@@ -5,6 +5,9 @@
 #
 # === Parameters
 #
+# [*nginx_manage*]
+#   Whether or not to manage the nginx service and package at all
+#
 # [*nginx_package*]
 #   The name of the Nginx package to install.
 #
@@ -20,10 +23,10 @@
 # [*consul_address*]
 #   The address for the Consul agent for Consul Template to connect to.
 class seed_stack::template_nginx (
-  $nginx_manage            = true,
-  $nginx_package           = 'nginx-light',
+  $nginx_manage            = $seed_stack::params::nginx_manage,
+  $nginx_package           = $seed_stack::params::nginx_package,
   $nginx_package_ensure    = $seed_stack::params::nginx_ensure,
-  $nginx_service_ensure    = 'running',
+  $nginx_service_ensure    = $seed_stack::params::nginx_service_ensure,
 
   $consul_template_version = $seed_stack::params::consul_template_version,
   $consul_address          = $seed_stack::params::consul_client_addr,

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -85,6 +85,8 @@ class seed_stack::worker (
   $consul_domain            = $seed_stack::params::consul_domain,
   $consul_encrypt           = undef,
   $consul_ui                = false,
+  $consul_template_version = $seed_stack::params::consul_template_version,
+  $consul_address          = $seed_stack::params::consul_client_addr,
 
   # Dnsmasq
   $dnsmasq_ensure           = $seed_stack::params::dnsmasq_ensure,
@@ -94,7 +96,10 @@ class seed_stack::worker (
   $consul_template_version  = $seed_stack::params::consul_template_version,
 
   # Nginx
+  $nginx_manage            = $seed_stack::params::nginx_manage,
   $nginx_ensure             = $seed_stack::params::nginx_ensure,
+  $nginx_package           = $seed_stack::params::nginx_package,
+  $nginx_service_ensure    = $seed_stack::params::nginx_service_ensure,
 
   # Docker
   $docker_ensure            = $seed_stack::params::docker_ensure,
@@ -176,11 +181,20 @@ class seed_stack::worker (
   }
 
   class { 'seed_stack::template_nginx':
+    nginx_manage            => $nginx_manage,
+    nginx_package           => $nginx_package,
+    nginx_service_ensure    => $nginx_service_ensure,
     nginx_package_ensure    => $nginx_ensure,
     consul_template_version => $consul_template_version,
     consul_address          => $consul_client_addr,
   }
   class { 'seed_stack::router':
+    nginx_manage            => $nginx_manage,
+    nginx_package           => $nginx_package,
+    nginx_service_ensure    => $nginx_service_ensure,
+    nginx_package_ensure    => $nginx_ensure,
+    consul_template_version => $consul_template_version,
+    consul_address          => $consul_client_addr,
     listen_addr => $advertise_addr,
     domain      => $dnsmasq_host_alias,
   }

--- a/spec/classes/load_balancer_spec.rb
+++ b/spec/classes/load_balancer_spec.rb
@@ -27,6 +27,13 @@ describe 'seed_stack::load_balancer' do
         end
       end
 
+      describe 'with nginx left alone' do
+        it { is_expected.to compile }
+        it { is_expected.to contain_class('seed_stack::template_nginx') }
+        it { is_expected.not_to contain_package('nginx-light') }
+        it { is_expected.not_to contain_service('nginx') }
+      end
+
       describe 'with custom parameters' do
         let(:params) { {:listen_addr => '192.168.0.1'} }
 

--- a/spec/classes/load_balancer_spec.rb
+++ b/spec/classes/load_balancer_spec.rb
@@ -28,6 +28,7 @@ describe 'seed_stack::load_balancer' do
       end
 
       describe 'with nginx left alone' do
+        let(:params) { {:nginx_manage => false} }
         it { is_expected.to compile }
         it { is_expected.to contain_class('seed_stack::template_nginx') }
         it { is_expected.not_to contain_package('nginx-light') }


### PR DESCRIPTION
Doing a bare include of template_nginx provided no means to override the defaults used in the load_balancer module
