### PR TITLE
Move nginx management somewhere more sensible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 0.8.1 - UNRELEASED
+## 0.9.0 - UNRELEASED
 ### Features
 * Consul 0.6.4 (#92)
+
+### Changes
+* `nginx` package and service management has moved from `seed_stack::template_nginx` to `seed_stack::router` and `seed_stack::load_balancer` to make it easier to override. (#94)
 
 ## 0.8.0 - 2016/03/15
 ### Features

--- a/manifests/load_balancer.pp
+++ b/manifests/load_balancer.pp
@@ -19,7 +19,7 @@ class seed_stack::load_balancer (
   validate_ip_address($listen_addr)
   validate_bool($nginx_manage)
 
-  if $nginx_manage {
+  if $nginx_manage and !defined(Package[$seed_stack::params::nginx_package]) {
     package { $seed_stack::params::nginx_package:
       ensure => $seed_stack::params::nginx_ensure,
     }->

--- a/manifests/load_balancer.pp
+++ b/manifests/load_balancer.pp
@@ -8,10 +8,25 @@
 # [*listen_addr*]
 #   The address that seed_stack::router is listening on. This prevents the more
 #   specific listen directive in that from masking our server blocks.
+#
+# [*nginx_manage*]
+#   Set to false to avoid managing the nginx package.
+#
 class seed_stack::load_balancer (
-  $listen_addr = $seed_stack::params::router_listen_addr,
+  $listen_addr  = $seed_stack::params::router_listen_addr,
+  $nginx_manage = true,
 ) inherits seed_stack::params {
   validate_ip_address($listen_addr)
+  validate_bool($nginx_manage)
+
+  if $nginx_manage {
+    package { $seed_stack::params::nginx_package:
+      ensure => $seed_stack::params::nginx_ensure,
+    }->
+    service { 'nginx':
+      ensure => 'running',
+    }
+  }
 
   include seed_stack::template_nginx
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -79,6 +79,8 @@ class seed_stack::params {
   $consul_template_version  = '0.14.0'
 
   $nginx_ensure             = 'installed'
+  $nginx_package            = 'nginx-light'
+
   $router_listen_addr       = $::ipaddress_lo
   $router_listen_port       = 80
   $router_domain            = 'servicehost'

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -15,13 +15,28 @@
 #
 # [*domain*]
 #   The domain that Nginx should serve for routing.
+#
+# [*nginx_manage*]
+#   Set to false to avoid managing the nginx package.
+#
 class seed_stack::router (
-  $listen_addr = $seed_stack::params::router_listen_addr,
-  $listen_port = $seed_stack::params::router_listen_port,
-  $domain      = $seed_stack::params::router_domain,
+  $listen_addr  = $seed_stack::params::router_listen_addr,
+  $listen_port  = $seed_stack::params::router_listen_port,
+  $domain       = $seed_stack::params::router_domain,
+  $nginx_manage = true,
 ) inherits seed_stack::params {
   validate_ip_address($listen_addr)
   validate_integer($listen_port, 65535, 1)
+  validate_bool($nginx_manage)
+
+  if $nginx_manage {
+    package { $seed_stack::params::nginx_package:
+      ensure => $seed_stack::params::nginx_ensure,
+    }->
+    service { 'nginx':
+      ensure => 'running',
+    }
+  }
 
   include seed_stack::template_nginx
 

--- a/manifests/router.pp
+++ b/manifests/router.pp
@@ -29,7 +29,7 @@ class seed_stack::router (
   validate_integer($listen_port, 65535, 1)
   validate_bool($nginx_manage)
 
-  if $nginx_manage {
+  if $nginx_manage and !defined(Package[$seed_stack::params::nginx_package]) {
     package { $seed_stack::params::nginx_package:
       ensure => $seed_stack::params::nginx_ensure,
     }->

--- a/manifests/template_nginx.pp
+++ b/manifests/template_nginx.pp
@@ -5,39 +5,16 @@
 #
 # === Parameters
 #
-# [*nginx_package*]
-#   The name of the Nginx package to install.
-#
-# [*nginx_package_ensure*]
-#   The ensure value for the Nginx package.
-#
-# [*nginx_service_ensure*]
-#   The ensure value for the Nginx service.
-#
 # [*consul_template_version*]
 #   The version of Consul Template to install.
 #
 # [*consul_address*]
 #   The address for the Consul agent for Consul Template to connect to.
 class seed_stack::template_nginx (
-  $nginx_manage            = true,
-  $nginx_package           = 'nginx-light',
-  $nginx_package_ensure    = $seed_stack::params::nginx_ensure,
-  $nginx_service_ensure    = 'running',
-
   $consul_template_version = $seed_stack::params::consul_template_version,
   $consul_address          = $seed_stack::params::consul_client_addr,
 ) inherits seed_stack::params {
   validate_ip_address($consul_address)
-
-  if $nginx_manage {
-    package { $nginx_package:
-      ensure => $nginx_package_ensure,
-    }->
-    service { 'nginx':
-      ensure => $nginx_service_ensure,
-    }
-  }
 
   if ! defined (Package['unzip']) {
     package { 'unzip':

--- a/manifests/worker.pp
+++ b/manifests/worker.pp
@@ -52,8 +52,8 @@
 # [*consul_template_version*]
 #   The version of Consul Template to install.
 #
-# [*nginx_ensure*]
-#   The ensure value for the Nginx package.
+# [*nginx_manage*]
+#   Set to false to avoid managing the nginx package.
 #
 # [*docker_ensure*]
 #   The package ensure value for Docker Engine.
@@ -94,7 +94,7 @@ class seed_stack::worker (
   $consul_template_version  = $seed_stack::params::consul_template_version,
 
   # Nginx
-  $nginx_ensure             = $seed_stack::params::nginx_ensure,
+  $nginx_manage             = true,
 
   # Docker
   $docker_ensure            = $seed_stack::params::docker_ensure,
@@ -176,13 +176,13 @@ class seed_stack::worker (
   }
 
   class { 'seed_stack::template_nginx':
-    nginx_package_ensure    => $nginx_ensure,
     consul_template_version => $consul_template_version,
     consul_address          => $consul_client_addr,
   }
   class { 'seed_stack::router':
-    listen_addr => $advertise_addr,
-    domain      => $dnsmasq_host_alias,
+    listen_addr  => $advertise_addr,
+    domain       => $dnsmasq_host_alias,
+    nginx_manage => $nginx_manage,
   }
 
   # Docker, using the host for DNS

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "praekeltfoundation-seed_stack",
-  "version": "0.8.1-dev",
+  "version": "0.9.0-dev",
   "author": "Jamie Hewland",
   "summary": "Meta-module for deploying the Seed Stack",
   "license": "BSD-3-Clause",

--- a/spec/classes/load_balancer_spec.rb
+++ b/spec/classes/load_balancer_spec.rb
@@ -9,13 +9,27 @@ describe 'seed_stack::load_balancer' do
 
       describe 'with default parameters' do
         it { is_expected.to compile }
+
+        it do
+          is_expected.to contain_package('nginx-light')
+            .with_ensure('installed')
+        end
+
+        it do
+          is_expected.to contain_service('nginx')
+            .with_ensure('running')
+            .that_requires('Package[nginx-light]')
+        end
+
         it { is_expected.to contain_class('seed_stack::template_nginx') }
+
         it do
           is_expected.to contain_file(
             '/etc/consul-template/nginx-websites.ctmpl')
             .with_content(/^\s*listen 80;/)
             .with_content(/^\s*listen 127\.0\.0\.1:80;/)
         end
+
         it do
           is_expected.to contain_consul_template__watch('nginx-websites')
             .with(
@@ -36,6 +50,12 @@ describe 'seed_stack::load_balancer' do
             .with_content(/^\s*listen 80;/)
             .with_content(/^\s*listen 192\.168\.0\.1:80;/)
         end
+      end
+
+      describe 'when nginx_manage is false' do
+        let(:params) { {:nginx_manage => false} }
+        it { is_expected.not_to contain_package('nginx-light') }
+        it { is_expected.not_to contain_service('nginx') }
       end
     end
   end

--- a/spec/classes/router_spec.rb
+++ b/spec/classes/router_spec.rb
@@ -10,6 +10,17 @@ describe 'seed_stack::router' do
       describe 'with default parameters' do
         it { is_expected.to compile }
 
+        it do
+          is_expected.to contain_package('nginx-light')
+            .with_ensure('installed')
+        end
+
+        it do
+          is_expected.to contain_service('nginx')
+            .with_ensure('running')
+            .that_requires('Package[nginx-light]')
+        end
+
         it { is_expected.to contain_class('seed_stack::template_nginx') }
 
         it do
@@ -47,6 +58,12 @@ describe 'seed_stack::router' do
               .with_content(/^\s*server_name dockerhost;$/)
           )
         end
+      end
+
+      describe 'when nginx_manage is false' do
+        let(:params) { {:nginx_manage => false} }
+        it { is_expected.not_to contain_package('nginx-light') }
+        it { is_expected.not_to contain_service('nginx') }
       end
     end
   end

--- a/spec/classes/template_nginx_spec.rb
+++ b/spec/classes/template_nginx_spec.rb
@@ -9,15 +9,8 @@ describe 'seed_stack::template_nginx' do
 
       describe 'with default parameters' do
         it { is_expected.to compile }
-        it do
-          is_expected.to contain_package('nginx-light')
-            .with_ensure('installed')
-        end
-        it do
-          is_expected.to contain_service('nginx')
-            .with_ensure('running')
-            .that_requires('Package[nginx-light]')
-        end
+        it { is_expected.not_to contain_package('nginx-light') }
+        it { is_expected.not_to contain_service('nginx') }
 
         it do
           is_expected.to contain_package('unzip')
@@ -55,12 +48,6 @@ describe 'seed_stack::template_nginx' do
             ).that_subscribes_to(
               'File[/etc/consul-template/nginx-upstreams.ctmpl]')
         end
-      end
-
-      describe 'when nginx_manage is false' do
-        let(:params) { {:nginx_manage => false} }
-        it { is_expected.not_to contain_package('nginx-light') }
-        it { is_expected.not_to contain_service('nginx') }
       end
     end
   end

--- a/spec/classes/worker_spec.rb
+++ b/spec/classes/worker_spec.rb
@@ -86,7 +86,6 @@ describe 'seed_stack::worker' do
 
         it do
           is_expected.to contain_class('seed_stack::template_nginx')
-            .with_nginx_package_ensure('installed')
             .with_consul_template_version(/\d+\.\d+\.\d+/)
             .with_consul_address('0.0.0.0')
         end
@@ -95,6 +94,7 @@ describe 'seed_stack::worker' do
           is_expected.to contain_class('seed_stack::router')
             .with_listen_addr('192.168.0.3')
             .with_domain('servicehost')
+            .with_nginx_manage(true)
         end
 
         it do


### PR DESCRIPTION
At the moment, `seed_stack::template_nginx` manages the `nginx` package. This is a problem, because it gets included in multiple places and gets really messy if nginx needs to be managed elsewhere.
