### PR TITLE
Consular set up to listen on default address (localhost)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Features
 * Docker 1.11.2 (#108)
 
+### Fixes
+* Consular now listens on and registers for Marathon events with the controller's advertise address. Every Consular instance in the cluster should now receive events, not just the instance on the leading Marathon host. (#106)
+
 ## 0.10.0 - 2016/05/13
 ### Features
 * Docker 1.11.1 (#105)

--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -223,6 +223,7 @@ class seed_stack::controller (
 
   class { 'consular':
     package_ensure => $consular_ensure,
+    host           => $advertise_addr,
     consul         => "http://${consul_client_addr}:8500",
     sync_interval  => $consular_sync_interval,
     purge          => true,


### PR DESCRIPTION
Every Consular instance registers itself as being at `127.0.0.1`. Only the leading Marathon instance emits events to listeners, so only the Consular instance running on the same host as the Marathon leader will receive events (and possibly event messages for all of the Consular instances).
