### PR TITLE
Some gem updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - rvm: "1.9.3"
       env: PUPPET_VERSION="~> 3.8.0" # Latest 3.x version
     - rvm: "2.1.8"
-      env: PUPPET_VERSION="~> 4.3.0" # Puppetlabs PC1 (latest 4.x version)
+      env: PUPPET_VERSION="~> 4" # Puppetlabs PC1 (latest 4.x version)
 env:
   global:
     - LIBRARIAN_PUPPET_TMP="$HOME/librarian-puppet"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,12 @@
 source 'https://rubygems.org'
 
 group :test do
-  gem 'rake', '<11.0.0' # See https://github.com/invadersmustdie/puppet-catalog-test/pull/29
+  # Rake's 'last_comment', which is used by puppet-catalog-test, was briefly
+  # removed in Rake 11.0.x. It will be removed in Rake 12.
+  # See release notes for Rake 11.0.0 and 11.1.0:
+  # https://github.com/ruby/rake/blob/master/History.rdoc
+  # ...and https://github.com/invadersmustdie/puppet-catalog-test/pull/29
+  gem 'rake', '>= 11.1.0', '< 12'
 
   puppetversion = ENV['PUPPET_VERSION'] || '~> 4'
   gem 'puppet', puppetversion

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 group :test do
   gem 'rake', '<11.0.0' # See https://github.com/invadersmustdie/puppet-catalog-test/pull/29
 
-  puppetversion = ENV['PUPPET_VERSION'] || ['>= 3.4.0', '< 4.0.0']
+  puppetversion = ENV['PUPPET_VERSION'] || '~> 4'
   gem 'puppet', puppetversion
 
   gem 'librarian-puppet'


### PR DESCRIPTION
- Puppetlabs PC1 package is up to Puppet 4.5.1 now, so just use 4.x by default rather than 4.3.x
- Newer Rake re-added `last_comment`
