### PR TITLE
0.9.x: Marathon 0.15.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## 0.9.6 - UNRELEASED
-
+* Marathon 0.15.6 (#113)
 
 ## 0.9.5 - 2016/06/03
 ### Features

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -71,7 +71,7 @@ class seed_stack::params {
   $mesos_listen_addr        = '0.0.0.0'
   $mesos_cluster            = 'seed-stack'
 
-  $marathon_ensure          = '0.15.5-1.0.477.ubuntu1404'
+  $marathon_ensure          = '0.15.6-1.0.484.ubuntu1404'
 
   $consul_version           = '0.6.4'
   $consul_client_addr       = '0.0.0.0'


### PR DESCRIPTION
Maintenance update for HelloMama
https://github.com/mesosphere/marathon/releases/tag/v0.15.6
