### PR TITLE
0.9.x: Reload Dnsmasq when /etc/hosts is changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 ### Features
 * Marathon 0.15.7 (#117)
 
+### Fixes
+* Reload Dnsmasq on changes to `/etc/hosts` (#118)
+
 ## 0.9.7 - 2016/08/30
 ### Features
 * Ability to specify additional command line options for Marathon (#116)

--- a/manifests/consul_dns.pp
+++ b/manifests/consul_dns.pp
@@ -162,4 +162,16 @@ class seed_stack::consul_dns (
   }
   ~>
   service { 'dnsmasq': }
+
+  # See Dnsmasq manpage notes for more information about the ways Dnsmasq
+  # handles signals. SIGHUP clears the cache and reloads certain files (most
+  # notably /etc/hosts) but does not reload /etc/dnsmasq.conf.
+  exec { 'dnsmasq_reload':
+    command     => 'kill -HUP $(cat /var/run/dnsmasq/dnsmasq.pid)',
+    path        => ['/bin'],
+    refreshonly => true,
+  }
+
+  # Reload dnsmasq on any changes to host resources
+  Host <| |> ~> Exec['dnsmasq_reload']
 }

--- a/spec/classes/consul_dns_spec.rb
+++ b/spec/classes/consul_dns_spec.rb
@@ -51,6 +51,15 @@ describe 'seed_stack::consul_dns' do
           is_expected.to contain_service('dnsmasq')
             .that_subscribes_to('File[/etc/dnsmasq.d/consul]')
         end
+
+        # FIXME: There doesn't seem to be an easy way to check that the reload
+        # command subscribes to all collected host resources.
+        it do
+          is_expected.to contain_exec('dnsmasq_reload')
+            .with_command('kill -HUP $(cat /var/run/dnsmasq/dnsmasq.pid)')
+            .with_path(['/bin'])
+            .with_refreshonly(true)
+        end
       end
 
       describe 'when advertise_addr is not set' do


### PR DESCRIPTION
- praekelt/puppet-org#57
- praekelt/puppet#1127
